### PR TITLE
Add tests for media query hook and metadata utility

### DIFF
--- a/src/hooks/use-media-query.test.ts
+++ b/src/hooks/use-media-query.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, act } from "@testing-library/react";
+import {
+	useMediaQuery,
+	useIsLargeScreen,
+	useIsMediumScreen,
+	useIsSmallScreen,
+} from "./use-media-query";
+
+describe("useMediaQuery", () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it("returns initial match value and updates on change", () => {
+		let changeListener: ((e: MediaQueryListEvent) => void) | null = null;
+		const mockMql = {
+			matches: false,
+			media: "(min-width: 768px)",
+			addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+				changeListener = cb;
+			},
+			removeEventListener: jest.fn(),
+		} as any;
+		// Override matchMedia for this test
+		const matchMediaSpy = jest
+			.spyOn(window, "matchMedia")
+			.mockReturnValue(mockMql);
+
+		const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+		expect(result.current).toBe(false);
+		expect(matchMediaSpy).toHaveBeenCalledWith("(min-width: 768px)");
+
+		act(() => {
+			mockMql.matches = true;
+			changeListener &&
+				changeListener({ matches: true } as MediaQueryListEvent);
+		});
+
+		expect(result.current).toBe(true);
+	});
+
+	it("cleans up listener on unmount", () => {
+		const removeListener = jest.fn();
+		const mockMql = {
+			matches: true,
+			media: "(min-width: 1024px)",
+			addEventListener: jest.fn(),
+			removeEventListener: removeListener,
+		} as any;
+		jest.spyOn(window, "matchMedia").mockReturnValue(mockMql);
+
+		const { unmount } = renderHook(() => useMediaQuery("(min-width: 1024px)"));
+		unmount();
+		expect(removeListener).toHaveBeenCalled();
+	});
+});
+
+describe("predefined breakpoint hooks", () => {
+	it("useIsLargeScreen uses correct media query", () => {
+		const spy = jest.spyOn(window, "matchMedia");
+		renderHook(() => useIsLargeScreen());
+		expect(spy).toHaveBeenCalledWith("(min-width: 1024px)");
+	});
+
+	it("useIsMediumScreen uses correct media query", () => {
+		const spy = jest.spyOn(window, "matchMedia");
+		renderHook(() => useIsMediumScreen());
+		expect(spy).toHaveBeenCalledWith("(min-width: 768px)");
+	});
+
+	it("useIsSmallScreen uses correct media query", () => {
+		const spy = jest.spyOn(window, "matchMedia");
+		renderHook(() => useIsSmallScreen());
+		expect(spy).toHaveBeenCalledWith("(max-width: 767px)");
+	});
+});

--- a/src/utils/metadata.test.ts
+++ b/src/utils/metadata.test.ts
@@ -1,0 +1,68 @@
+import { createMetadata } from "./metadata";
+
+describe("createMetadata", () => {
+	it("merges overrides with defaults", () => {
+		const metadata = createMetadata({
+			title: "My Title",
+			description: "My description",
+			openGraph: { type: "article" },
+			twitter: { card: "summary" },
+		} as any);
+
+		expect(metadata.openGraph).toEqual(
+			expect.objectContaining({
+				title: "My Title",
+				description: "My description",
+				url: "https://designcombo.dev",
+				images: "/banner.png",
+				siteName: "Combo",
+				type: "article",
+			}),
+		);
+
+		expect(metadata.twitter).toEqual(
+			expect.objectContaining({
+				card: "summary",
+				creator: "@Combo",
+				title: "My Title",
+				description: "My description",
+				images: "/banner.png",
+			}),
+		);
+
+		expect(metadata.icons).toEqual({ icon: "/icon.svg" });
+	});
+
+	it("handles missing title and description", () => {
+		const metadata = createMetadata({} as any);
+		expect(metadata.openGraph.title).toBeUndefined();
+		expect(metadata.openGraph.description).toBeUndefined();
+		expect(metadata.twitter.title).toBeUndefined();
+		expect(metadata.twitter.description).toBeUndefined();
+	});
+});
+
+describe("baseUrl", () => {
+	const originalEnv = process.env.NODE_ENV;
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalEnv;
+		jest.resetModules();
+	});
+
+	it("uses localhost in development", () => {
+		process.env.NODE_ENV = "development";
+		jest.isolateModules(() => {
+			const { baseUrl } = require("./metadata");
+			expect(baseUrl.href).toBe("http://localhost:3000/");
+		});
+	});
+
+	it("uses production url otherwise", () => {
+		process.env.NODE_ENV = "production";
+		jest.isolateModules(() => {
+			const { baseUrl } = require("./metadata");
+			expect(baseUrl.href).toBe("https://designcombo.dev/");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- test media query hook behavior and cleanup
- test metadata creation and baseUrl handling

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ad168dd2448327910b0b44d0280089